### PR TITLE
BACK. Get product by ID

### DIFF
--- a/api/src/routes/products/products.js
+++ b/api/src/routes/products/products.js
@@ -142,7 +142,14 @@ router.get('/:id', async (req, res) => {
         const product = await Product.findOne({
             where: {
                 id: id
-            }
+            },
+            include: [
+                { model: Brand }, // include[0]
+                { model: Type }, // include[1]
+                { model: Storage }, // include[2]
+                { model: Review }, // include[3]
+                { model: Ram } // include[4]
+            ]
         });
         if (product === null) {
             return res.status(400).json({ err: `The enter id does not exist.` })


### PR DESCRIPTION
Cuando se hacía una petición get a /product/id devolvía solo los foreinkey de las demás tablas relacionadas con productos.
El cambio es para responder con toda la información relacionada del producto.