### PR TITLE
FRONT. Correccion peticiones API

### DIFF
--- a/client/src/Component/Filters/Filters.jsx
+++ b/client/src/Component/Filters/Filters.jsx
@@ -42,12 +42,8 @@ function Filters() {
 
 
   useEffect(() => {
-    dispatch(getProductsByQuery(search))
     dispatch(getAllFilters())
-  }, [dispatch, select])
-
-
-
+  }, [])
 
   const toggle = (e) => {
 
@@ -62,18 +58,16 @@ function Filters() {
   const handleSelect = (e) => {
     if (e.target.name === 'sortPrice') {
       if(query.get(e.target.name) === e.target.value){
-        console.log("adentro")
         query.delete(e.target.name)
-        query.set('offset', 0) 
         history.push({ search: query.toString() })
         setSelect({...select,price:""})
         return
       }
       query.set(e.target.name,e.target.value)
-      query.set('offset', 0) 
+      query.delete('offset');
+      query.delete('limit');
       setSelect({ ...select, price: e.target.value })
       history.push({ search: query.toString() })
-      dispatch(getProductsByQuery(search))
       return
     }
     if (e.target.name === "type") {
@@ -81,21 +75,23 @@ function Filters() {
       let toLower = withOutS[0].toLowerCase() + withOutS.slice(1)
       if(query.get(e.target.name) === toLower){
         query.delete(e.target.name)
-        query.set('offset', 0) 
+        query.delete('offset');
+        query.delete('limit');
         history.push({ search: query.toString() })
         setSelect({...select,[e.target.name]:""})
         return
       }
       setSelect({ ...select, [e.target.name]: toLower })
       query.set(e.target.name, toLower)
-      query.set('offset', 0) 
+      query.delete('offset');
+      query.delete('limit');
       history.push({ search: query.toString() })
-      dispatch(getProductsByQuery(search))
       return
     }
     if(query.get(e.target.name) === e.target.value){
       query.delete(e.target.name)
-      query.set('offset', 0) 
+      query.delete('offset');
+      query.delete('limit');
       history.push({ search: query.toString() })
       setSelect({...select,[e.target.name]:""})
       return
@@ -103,9 +99,9 @@ function Filters() {
 
     setSelect({ ...select, [e.target.name]: e.target.value })
     query.set(e.target.name, e.target.value)
-    query.set('offset', 0) 
+    query.delete('offset');
+    query.delete('limit');
     history.push({ search: query.toString() })
-    dispatch(getProductsByQuery(search))
   }
 
   const handleClear = () => {
@@ -117,7 +113,6 @@ function Filters() {
       price: "",
       ram:""
     })
-
     query.delete("brand")
     query.delete("sortPrice")
     query.delete("type")
@@ -127,7 +122,7 @@ function Filters() {
     query.delete('limit')
     query.delete('name')
     history.push({ search: query.toString() })
-    dispatch(getProductsByQuery(search))
+    dispatch(getProductsByQuery(''))
   }
 
   return (
@@ -137,7 +132,7 @@ function Filters() {
 
       <div className={styles.block_container}>
         <div className={styles.block_container_title} id="category" onClick={toggle} >
-          Categegory
+          Category
           <MdKeyboardArrowDown className={active.category ? styles.arrow_active : ""} />
         </div>
         <div className={active.category ? `${styles.options_container} ${styles.active}` : styles.options_container}>

--- a/client/src/Component/NavBar/NavBar.jsx
+++ b/client/src/Component/NavBar/NavBar.jsx
@@ -3,7 +3,6 @@ import { useDispatch , useSelector } from 'react-redux';
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { FiUserCheck } from 'react-icons/fi'
 import { getProductsByQuery } from '../../Redux/Actions/products.js'
-// import Button from '../Button/Button.jsx'; 
 import logo from '../../Assets/logo.png'
 import styles from './NavBar.module.css';
 import ModalRegister from "../ModalRegister/ModalRegister.jsx";
@@ -21,34 +20,22 @@ import { clearCarts } from "../../Redux/Actions/cart.js";
 const NavBar = () => {
 
   const [input, setInput] = useState('');
-  const [crud, setCrud] = useState({})
   const [modalShow, setModalShow] = useState(false);
   const [displayOptions, setDisplayOptions] = useState(false)
 
   const state = useSelector(state=>state)
   const dispatch = useDispatch();
 
-  const {search,pathname} = useLocation()
+  const {search} = useLocation()
   const history = useHistory()
   const query = new URLSearchParams(search)
 
-
   useEffect(()=>{
-    if (pathname === '/Create/Product'){
-      setCrud({create:true})
-      return
-    }
-    else {
-      setCrud({create:false})
-    }
-  },[pathname])
-
-  useEffect(()=>{
-    dispatch(getProductsByQuery(search))
+    if(!search && state.filteredProducts.length === 0)
+      dispatch(getProductsByQuery(search))
+    if(search)
+      dispatch(getProductsByQuery(search))
   },[search])
-
-
-
 
   const handleInputChange = e => {
     setInput(e.target.value);
@@ -57,8 +44,7 @@ const NavBar = () => {
   const handleSubmit = e => {
     e.preventDefault();
     query.set('name',input)   
-    query.set('offset', 0) 
-    dispatch(getProductsByQuery(search));
+    query.set('offset', 0)
     history.push({search:query.toString()})
   };
 
@@ -67,8 +53,8 @@ const NavBar = () => {
     
     query.delete("name")
     history.push({search:query.toString()})
-    dispatch(getProductsByQuery(search));
     setInput('');
+    dispatch(getProductsByQuery(search));
   };
 
   const handleDisplayOptions = ()=> {

--- a/client/src/Component/Pagination/Pagination.jsx
+++ b/client/src/Component/Pagination/Pagination.jsx
@@ -5,10 +5,7 @@ import { useHistory } from 'react-router-dom'
 import { useLocation } from 'react-router-dom';
 
 import { objectToQuery } from '../../hooks/ObjectToQuery'
-
-
 import { setPageView } from '../../Redux/Actions/index.js';
-import { getProductsByQuery } from '../../Redux/Actions/products.js';
 
 import styles from './Pagination.module.css'
 
@@ -64,15 +61,11 @@ const Pagination = () => {
   const pages = Math.ceil(totalProducts / productsPerPage);
   const maxPages = 5;
 
-  const queryNew = useQueryParams();
-
   const handleInputChange = (e) => {
     dispatch(setPageView(e.target.value));
-    queryNew.limit = productsPerPage;
-    queryNew.offset = e.target.value * productsPerPage - productsPerPage;
-    let string = objectToQuery(queryNew);
-    dispatch(getProductsByQuery(`?${string}`));
-    history.push(`?${string}`);
+    query.set('limit', productsPerPage);
+    query.set('offset', e.target.value * productsPerPage - productsPerPage);
+    history.push({ search: query.toString() });
   }
 
   const handleInputLess = (e) => {
@@ -92,7 +85,7 @@ const Pagination = () => {
       dispatch(setPageView(pages))
     }
     setShownPages(stripedPagination(pages, page, maxPages))
-  }, [products, page, totalProducts, pages, limit, offset, dispatch]);
+  }, [products, totalProducts, pages, limit, offset, dispatch]);
   
   // SOBRE LO QUE SIGUE... NO PREGUNTEN, FUNCIONA OK 😁
   return (


### PR DESCRIPTION
Se hacen cambios en las veces que se hacen peticiones al server.
Será muy útil para cuando esté deployado, ahí se va a notar mucho.
Ya se evita el doble montado del componente Product que pasaba de vez en cuando (como un doble refress).

Filter.
- Se quita getProductsByQuery, no hace falta ya lo hace la NavBar. Si se deja cuando se limpian los filtros.
- Además se ejecuta getAllFilters solo cada vez que se monta. Las categorías no van a cambiar tan seguido como para hacer esta petición en cada cambio de variable.

NavBar
- Se quita todos los getProductsByQuery salvo el del useEffect. No hace falta llamarlo cada vez en el resto del código ya que cuando cambia de estado la variable search el useEffect se ejecuta con el getProductsByQuery.
- Se pone condicional en useEffect porque al hacer una búsqueda e ir al detalle (cambia el path) la variable search se vacía y hacía que se llame otra vez a getProductsByQuery sin ncesidad.
- Se quita variable pathname, no hacía nada.

Pagination
- Se quita getProductsByQuery. Ya al seleccionar la página la búsqueda la hace el NavBar.
- Se setea history, con ello el NavBar ya hace la petición.
