### PR TITLE
Oculto al cliente productos inactivos

### DIFF
--- a/api/src/routes/products/products.js
+++ b/api/src/routes/products/products.js
@@ -50,6 +50,7 @@ router.get('/', async (req, res) => {
         };
 
         let where = {};
+        where.active = true;
 
         if (name) {
             where.name = { [Sequelize.Op.iLike]: `%${name}%` }


### PR DESCRIPTION
Agrego where en la ruta de productos para que solo se vean en el front los productos activos. (no afecta a los productos que ve el admin en su crud)