### PR TITLE
CHE QL

### DIFF
--- a/client/src/Component/Checkout/CheckoutForm.jsx
+++ b/client/src/Component/Checkout/CheckoutForm.jsx
@@ -59,7 +59,7 @@ export default function CheckoutForm() {
       elements,
       confirmParams: {
         // Make sure to change this to your payment completion page
-        return_url: "http://localhost:3000/payment",
+        return_url: window.location.origin + "/payment",
       },
     });
 

--- a/client/src/Component/Checkout/Steps/Payment.jsx
+++ b/client/src/Component/Checkout/Steps/Payment.jsx
@@ -19,7 +19,8 @@ import { URL } from "../../../Redux/Constants";
 // Make sure to call loadStripe outside of a component’s render to avoid
 // recreating the Stripe object on every render.
 // This is your test publishable API key.
-const stripePromise = loadStripe("pk_test_51MG4j9KeVpay6lghl5aFDksbQDvpIDC8wZESVybDbtRc87wWpUynzmcp4UI5AgNRRzaU7o3VybGtWLQKMd0NBeXC005CZYGKTb");
+const API_KEY = process.env.REACT_APP_API_KEY;
+const stripePromise = loadStripe(API_KEY);
 
 export default function Payment() {
     const [clientSecret, setClientSecret] = useState("");

--- a/client/src/Component/Checkout/Steps/Payment.jsx
+++ b/client/src/Component/Checkout/Steps/Payment.jsx
@@ -20,7 +20,7 @@ import { URL } from "../../../Redux/Constants";
 // recreating the Stripe object on every render.
 // This is your test publishable API key.
 const stripePromise = loadStripe(process.env.REACT_APP_STRIPE);
-console.log(process.env.REACT_APP_STRIPE)
+
 export default function Payment() {
     const [clientSecret, setClientSecret] = useState("");
     const user = useSelector(state =>state.user)

--- a/client/src/Component/Checkout/Steps/Payment.jsx
+++ b/client/src/Component/Checkout/Steps/Payment.jsx
@@ -19,9 +19,8 @@ import { URL } from "../../../Redux/Constants";
 // Make sure to call loadStripe outside of a component’s render to avoid
 // recreating the Stripe object on every render.
 // This is your test publishable API key.
-const API_KEY = process.env.REACT_APP_API_KEY;
-const stripePromise = loadStripe(API_KEY);
-
+const stripePromise = loadStripe(process.env.REACT_APP_STRIPE);
+console.log(process.env.REACT_APP_STRIPE)
 export default function Payment() {
     const [clientSecret, setClientSecret] = useState("");
     const user = useSelector(state =>state.user)


### PR DESCRIPTION
Ahí está la variable de entorno para Stripe. La tuve que renombrar ya que si la variable no empieza con con REACT_APP, React la ignora.
Además se agrega en el step Payment que tome la url del dominio donde se está ejecutando, evitando crear otro variable de entorno.

@cvirgili438 