### PR TITLE
Send grid config

### DIFF
--- a/api/src/controller/objectToAdd/newsletter.js
+++ b/api/src/controller/objectToAdd/newsletter.js
@@ -1,11 +1,4 @@
 module.exports = [
     { email: 'prueba01@henrygadget.com', code: 101, confirm: true },
-    { email: 'prueba02@henrygadget.com', code: 102, confirm: true },
-    { email: 'prueba03@henrygadget.com', code: 103, confirm: true },
-    { email: 'prueba04@henrygadget.com', code: 104, confirm: true },
-    { email: 'prueba05@henrygadget.com', code: 105, confirm: false },
-    { email: 'prueba06@henrygadget.com', code: 106, confirm: false },
-    { email: 'prueba07@henrygadget.com', code: 107, confirm: true },
-    { email: 'prueba08@henrygadget.com', code: 108, confirm: true },
-    { email: 'prueba09@henrygadget.com', code: 109, confirm: true },
+    { email: 'prueba02@henrygadget.com', code: 102, confirm: false },
 ];

--- a/api/src/routes/config/sendgrid-config.js
+++ b/api/src/routes/config/sendgrid-config.js
@@ -6,5 +6,7 @@ const sgClient = require('@sendgrid/client');
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 // Para consigurar datos en la API de SendGrid.
 sgClient.setApiKey(process.env.SENDGRID_API_KEY);
+// Para formato base de los newsletters.
+const perzonalitationId = process.env.SENDGRID_PERSONALIZATION_ID;
 
-module.exports = { sgMail, sgClient }
+module.exports = { sgMail, sgClient, perzonalitationId }

--- a/api/src/routes/emails/constants/dataToSendMail.js
+++ b/api/src/routes/emails/constants/dataToSendMail.js
@@ -1,5 +1,4 @@
 const EMAIL_FROM_NEWSLETTER = { email: 'proyectofinalhenrygadget@gmail.com', name: 'HenryGadget' };
-const PERSONALIZATION_ID = "d-6f40d484fddb4b98966a70d03ea3a122";
 
 const SUBJECT_SUBSCRIBE = 'HenryGadget: Confirm your subscription to our newsletter';
 const SUBJECT_CONFIRM = 'HenryGadget: Subscription succeed.';
@@ -19,6 +18,5 @@ module.exports = {
     SUBJECT_SENDMAIL,
     htmlSubscribe,
     HTML_CONFIRM,
-    HTML_UNSUBSCRIBE,
-    PERSONALIZATION_ID
+    HTML_UNSUBSCRIBE
 };

--- a/api/src/routes/emails/newsletter.js
+++ b/api/src/routes/emails/newsletter.js
@@ -3,11 +3,10 @@ const router = express.Router();
 
 const { Newsletter } = require('../../db.js');
 
-const { sgMail } = require('../config/sendgrid-config.js');
+const { sgMail, perzonalitationId } = require('../config/sendgrid-config.js');
 
 const {
     EMAIL_FROM_NEWSLETTER,
-    PERSONALIZATION_ID,
     SUBJECT_SUBSCRIBE,
     SUBJECT_CONFIRM,
     SUBJECT_UNSUBSCRIBE,
@@ -151,7 +150,7 @@ router.post('/sendmail', async (req, res) => {
 
         const msg = {
             personalizations,
-            template_id: PERSONALIZATION_ID,
+            template_id: perzonalitationId,
             from: EMAIL_FROM_NEWSLETTER
         };
 


### PR DESCRIPTION
Se eliminan algunos mail de la función de carga de datos para no enviar tantos mail y no gastar la cuota de mail de SendGrid.

Se configura como variable de entorno perzonalitationId  de SendGrid, ya que al tener que crear una cuenta nueva veo que van de la mano con la API.