### PR TITLE
Descripcion iphones, y minimo CSS en discount products

### DIFF
--- a/api/src/controller/objectToAdd/iphoneProducts.js
+++ b/api/src/controller/objectToAdd/iphoneProducts.js
@@ -7,7 +7,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Super Retina Xdr Display, Fast Wireless Charging, Dust-Resistant, OLED Display, Telephoto Lens, Water-Resistant, 4K Video Recording.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone-14-pro-max-colors.png']
       },
     {
@@ -18,7 +18,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: '3D Depth Camera, 3D Depth Sensor, 3D Face Recognition, 4K Video Recording, Accelerometer, Ambient Light Sensor.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone-14-pro-colors.png']
       },
     {
@@ -29,7 +29,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Optical Image Stabilization, 4K Video Recording, Accelerometer, Barometer, Bluetooth Enabled, Digital Compass, Dual Front Camera.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone-14-plus-colors.png']
       },
     {
@@ -40,7 +40,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Super Retina Xdr Display, Fast Wireless Charging, Dust-Resistant, OLED Display, Telephoto Lens, Water-Resistant, 4K Video Recording.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone-14-colors.png']
       },
     {
@@ -51,7 +51,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: '3D Depth Camera, 3D Depth Sensor, 3D Face Recognition, 4K Video Recording, Accelerometer, Ambient Light Sensor.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone-se-3rd-gen-colors.png']
       },
     {
@@ -62,7 +62,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Optical Image Stabilization, 4K Video Recording, Accelerometer, Barometer, Bluetooth Enabled, Digital Compass, Dual Front Camera.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/2022-spring-iphone13-pro-max-colors.png']
       },
     {
@@ -73,7 +73,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Super Retina Xdr Display, Fast Wireless Charging, Dust-Resistant, OLED Display, Telephoto Lens, Water-Resistant, 4K Video Recording.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/2022-spring-iphone13-pro-colors.png']
       },
     {
@@ -84,7 +84,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: '3D Depth Camera, 3D Depth Sensor, 3D Face Recognition, 4K Video Recording, Accelerometer, Ambient Light Sensor.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/2022-spring-iphone13-colors.png']
       },
     {
@@ -95,7 +95,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: '3D Depth Camera, 3D Depth Sensor, 3D Face Recognition, 4K Video Recording, Accelerometer, Ambient Light Sensor.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/2022-iphone13-mini-colors.png']
       },
     {
@@ -106,7 +106,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Super Retina Xdr Display, Fast Wireless Charging, Dust-Resistant, OLED Display, Telephoto Lens, Water-Resistant, 4K Video Recording.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone12promax/iphone12-pro-max-colors.jpg']
       },
     {
@@ -117,7 +117,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Super Retina Xdr Display, Fast Wireless Charging, Dust-Resistant, OLED Display, Telephoto Lens, Water-Resistant, 4K Video Recording.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone12pro/iphone12-pro-colors.jpg']
       },
     {
@@ -128,7 +128,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Optical Image Stabilization, 4K Video Recording, Accelerometer, Barometer, Bluetooth Enabled, Digital Compass, Dual Front Camera.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/2021-iphone12-colors.png'],
           discount:'20'
       },
@@ -140,7 +140,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: '3D Depth Camera, 3D Depth Sensor, 3D Face Recognition, 4K Video Recording, Accelerometer, Ambient Light Sensor.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/2021-iphone12-mini-colors.png'],
           discount:'25'
       },
@@ -152,7 +152,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Super Retina Xdr Display, Fast Wireless Charging, Dust-Resistant, OLED Display, Telephoto Lens, Water-Resistant, 4K Video Recording.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone_se/iphone-se-2nd-gen-colors.jpg']
       },
     {
@@ -163,7 +163,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Optical Image Stabilization, 4K Video Recording, Accelerometer, Barometer, Bluetooth Enabled, Digital Compass, Dual Front Camera.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/identify-iphone-11pro.jpg']
       },
     {
@@ -174,7 +174,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Super Retina Xdr Display, Fast Wireless Charging, Dust-Resistant, OLED Display, Telephoto Lens, Water-Resistant, 4K Video Recording.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/identify-iphone-11pro-max.jpg'
         ],
         discount:'10'
@@ -187,7 +187,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: '3D Depth Camera, 3D Depth Sensor, 3D Face Recognition, 4K Video Recording, Accelerometer, Ambient Light Sensor.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/identify-iphone-11-colors.jpg']
       },
     {
@@ -198,7 +198,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Optical Image Stabilization, 4K Video Recording, Accelerometer, Barometer, Bluetooth Enabled, Digital Compass, Dual Front Camera.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone-xs-colors.jpg']
       },
     {
@@ -209,7 +209,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: '3D Depth Camera, 3D Depth Sensor, 3D Face Recognition, 4K Video Recording, Accelerometer, Ambient Light Sensor.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone-xs-max-colors.jpg']
       },
     {
@@ -220,7 +220,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Optical Image Stabilization, 4K Video Recording, Accelerometer, Barometer, Bluetooth Enabled, Digital Compass, Dual Front Camera.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone-xr/identify-iphone-xr-colors.jpg']
       },
     {
@@ -231,7 +231,7 @@ module.exports = [
           stock: 13,
           camera: '10Mpx',
           processor: 'OctaCore',
-          description: 'Alguna muy buena descripción sobre el producto.',
+          description: 'Super Retina Xdr Display, Fast Wireless Charging, Dust-Resistant, OLED Display, Telephoto Lens, Water-Resistant, 4K Video Recording.',
           img: ['https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iphone/iphone-x-colors.jpg']
       },
   

--- a/api/src/controller/objectToAdd/products.js
+++ b/api/src/controller/objectToAdd/products.js
@@ -20,7 +20,7 @@ module.exports = [
         price: 120,
         model: 'Buds 120',
         stock: 3,
-        description: 'Built-in Microphone, Call functions, Extra Bass, HD Voice, Noise Isolation, Replaceable Ear Tips, Stereo, Sweat-Proof, Touch Control, Water-Resistant, Wireless, Single Master Feature, 15h Playtime, Compact',
+        description: 'Built-in Microphone, Extra Bass, HD Voice, Noise Isolation, Replaceable Ear Tips, Stereo, Touch Control, Water-Resistant, Wireless, Compact',
         img: ['https://motorolaus.vtexassets.com/arquivos/ids/162201-800-auto',
             'https://motorolaus.vtexassets.com/arquivos/ids/162202-800-auto'],
         discount:'15'
@@ -32,7 +32,7 @@ module.exports = [
         stock: 13,
         camera: '10Mpx',
         processor: 'OctaCore',
-        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Active Edge, Ambient Light Sensor, Bluetooth Enabled, Camera, FM Radio, 4G Data Capable, Dual SIM, 3G Data Capable, Email, Colour Screen, 5G.',
+        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Camera, FM Radio, Dual SIM, 3G Data Capable, Colour Screen, 5G.',
         img: ['https://fdn2.gsmarena.com/vv/pics/xiaomi/xiaomi-redmi-note-12-pro-plus-1.jpg',
             'https://fdn2.gsmarena.com/vv/pics/xiaomi/xiaomi-redmi-note-12-pro-plus-2.jpg'],
         discount:'15'
@@ -44,7 +44,7 @@ module.exports = [
         stock: 4,
         camera: '100Mpx',
         processor: 'OctaCore',
-        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Active Edge, Ambient Light Sensor, Bluetooth Enabled, Camera, FM Radio, 4G Data Capable, Dual SIM, 3G Data Capable, Email, Colour Screen, 5G.',
+        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Camera, FM Radio, Dual SIM, 3G Data Capable, Colour Screen, 5G.',
         img: ['https://fdn2.gsmarena.com/vv/pics/xiaomi/xiaomi-poco-x4-pro-1.jpg',
             'https://fdn2.gsmarena.com/vv/pics/xiaomi/xiaomi-poco-x4-pro--.jpg'],
         discount:'10'
@@ -133,7 +133,7 @@ module.exports = [
         stock: 0,
         camera: '10Mpx',
         processor: 'OctaCore',
-        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Active Edge, Ambient Light Sensor, Bluetooth Enabled, Camera, FM Radio, 4G Data Capable, Dual SIM, 3G Data Capable, Email, Colour Screen, 5G.',
+        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Camera, FM Radio, Dual SIM, 3G Data Capable, Colour Screen, 5G.',
         img: ['https://fdn2.gsmarena.com/vv/pics/samsung/samsung-galaxy-m13-5g-1.jpg']
     },
     {
@@ -143,7 +143,7 @@ module.exports = [
         stock: 0,
         camera: '10Mpx',
         processor: 'OctaCore',
-        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Active Edge, Ambient Light Sensor, Bluetooth Enabled, Camera, FM Radio, 4G Data Capable, Dual SIM, 3G Data Capable, Email, Colour Screen, 5G.',
+        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Camera, FM Radio, Dual SIM, 3G Data Capable, Colour Screen, 5G.',
         img: ['https://fdn2.gsmarena.com/vv/pics/huawei/huawei-p30-lite-2.jpg']
     },
     {
@@ -163,7 +163,7 @@ module.exports = [
         stock: 4,
         camera: '10Mpx',
         processor: 'OctaCore',
-        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Active Edge, Ambient Light Sensor, Bluetooth Enabled, Camera, FM Radio, 4G Data Capable, Dual SIM, 3G Data Capable, Email, Colour Screen, 5G.',
+        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Camera, FM Radio, Dual SIM, 3G Data Capable, Colour Screen, 5G.',
         img: ['https://fdn2.gsmarena.com/vv/pics/htc/htc-wildfire-e2-plus-1.jpg']
     },
     {
@@ -183,7 +183,7 @@ module.exports = [
         stock: 13,
         camera: '10Mpx',
         processor: 'OctaCore',
-        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Active Edge, Ambient Light Sensor, Bluetooth Enabled, Camera, FM Radio, 4G Data Capable, Dual SIM, 3G Data Capable, Email, Colour Screen, 5G.',
+        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Camera, FM Radio, Dual SIM, 3G Data Capable, Colour Screen, 5G.',
         img: ['https://fdn2.gsmarena.com/vv/pics/realme/realme-10-pro-1.jpg']
     },
     {
@@ -213,7 +213,7 @@ module.exports = [
         stock: 5,
         camera: '10Mpx',
         processor: 'OctaCore',
-        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Active Edge, Ambient Light Sensor, Bluetooth Enabled, Camera, FM Radio, 4G Data Capable, Dual SIM, 3G Data Capable, Email, Colour Screen, 5G.',
+        description: '3D Depth Camera, 3D Depth Sensor, 4K Video Recording, Accelerometer, Camera, FM Radio, Dual SIM, 3G Data Capable, Colour Screen, 5G.',
         img: ['https://fdn2.gsmarena.com/vv/pics/microsoft/microsoft-surface-duo-03.jpg']
     },
 ]

--- a/client/src/Component/DiscountProducts/DiscountProducts.jsx
+++ b/client/src/Component/DiscountProducts/DiscountProducts.jsx
@@ -48,7 +48,7 @@ function DiscountProducts() {
         navigation={true}
         modules={[Pagination, Navigation]}
         className="mySwiper"
-        style={{ height: "20rem", margin: "auto" }}
+        style={{ height: "25rem", margin: "auto" }}
       >
         {discountProducts ? (
           discountProducts.map((e) => (


### PR DESCRIPTION
1. Agrego las descripciones de los iphones, que seguian con texto default
2. Corrijo minimo CSS en discount products, cuando hay mucho texto se superpone con otras cosas.